### PR TITLE
Minor 'migratein' tweak

### DIFF
--- a/ctl/cmd/migratein.rb
+++ b/ctl/cmd/migratein.rb
@@ -11,7 +11,7 @@ def cmd_migratein(options)
     
     puts "migrating all .DS_Store files from #{root} into #{PREFIX_PATH}"
     
-    Dir.glob(File.join(root, "**", ".DS_Store")) do |source|
+    Dir.glob(File.join(root, "**", ".DS_Store"), File::FNM_DOTMATCH) do |source|
         dest = File.join(PREFIX_PATH, source)
         dest[-9] = "_" # /some/path/.DS_Store -> /some/path/_DS_Store
         


### PR DESCRIPTION
By default, the "**" recursive directory wildcard match of Dir.glob does not match directories beginning with a '.', causing "asepsisctl migratein" to miss any .DS_Store files contained in them.  This is fixed by simply adding a flag to the Dir.glob call.

**Test**

```
mylaptop:~ psm14$ mkdir aseptest
mylaptop:~ psm14$ cd aseptest/
mylaptop:aseptest psm14$ touch .DS_Store
mylaptop:aseptest psm14$ mkdir .test
mylaptop:aseptest psm14$ touch .test/.DS_Store
mylaptop:aseptest psm14$ mkdir .test/test2
mylaptop:aseptest psm14$ touch .test/test2/.DS_Store
mylaptop:aseptest psm14$ mkdir .test/.test3
mylaptop:aseptest psm14$ touch .test/.test3/.DS_Store
mylaptop:aseptest psm14$ asepsisctl migratein -v
trying to lock /usr/local/.dscage/.asepsis.suspend.lock
migrating all .DS_Store files from /Users/psm14 into /usr/local/.dscage
mv -f /Users/psm14/aseptest/.DS_Store /usr/local/.dscage/Users/psm14/aseptest/_DS_Store
mv -f /Users/psm14/aseptest/.test/.DS_Store /usr/local/.dscage/Users/psm14/aseptest/.test/_DS_Store
mv -f /Users/psm14/aseptest/.test/.test3/.DS_Store /usr/local/.dscage/Users/psm14/aseptest/.test/.test3/_DS_Store
mv -f /Users/psm14/aseptest/.test/test2/.DS_Store /usr/local/.dscage/Users/psm14/aseptest/.test/test2/_DS_Store

removed lock /usr/local/.dscage/.asepsis.suspend.lock
moved 4 .DS_Store file(s) into the prefix folder
mylaptop:aseptest psm14$ 
```
